### PR TITLE
Fix broken builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,10 @@
+# Base bazelrc for devx-tools
+
+# Backwards compatible flags
+build --incompatible_new_actions_api=false
+build --incompatible_disable_deprecated_attr_params=false
+build --incompatible_depset_is_not_iterable=false
+build --incompatible_no_support_tools_in_action_inputs=false
+build --incompatible_require_ctx_in_configure_features=false
+build --incompatible_string_join_requires_strings=false
+build --host_force_python=PY2

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,8 +3,6 @@ workspace(name = "devx")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # Maven rule for transitive dependencies
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 RULES_JVM_EXTERNAL_TAG = "1.2"
 RULES_JVM_EXTERNAL_SHA = "e5c68b87f750309a79f59c2b69ead5c3221ffa54ff9496306937bfa1c9c8c86b"
 
@@ -16,6 +14,22 @@ http_archive(
 )
 
 load("@rules_jvm_external//:defs.bzl", "maven_install")
+
+# gRPC Java
+# Note that this needs to come before io_bazel_go_rules. Both depend on
+# protobuf and the version that io_bazel_rules_go depends on is broken for
+# java, so io_grpc_grpc_java needs to get the dep first.
+http_archive(
+    name = "io_grpc_grpc_java",
+    sha256 = "9bc289e861c6118623fcb931044d843183c31d0e4d53fc43c4a32b56d6bb87fa",
+    strip_prefix = "grpc-java-1.21.0",
+    urls = ["https://github.com/grpc/grpc-java/archive/v1.21.0.tar.gz"],
+)
+
+
+load("@io_grpc_grpc_java//:repositories.bzl", "grpc_java_repositories")
+
+grpc_java_repositories()
 
 # Go toolchains
 http_archive(
@@ -46,22 +60,6 @@ go_repository(
     name = "org_golang_x_sync",
     commit = "1d60e4601c6fd243af51cc01ddf169918a5407ca",
     importpath = "golang.org/x/sync",
-)
-
-# Java toolchains
-
-# gRPC Java
-http_archive(
-    name = "io_grpc_grpc_java",
-    sha256 = "0b86e44f9530fd61eb044b3c64c7579f21857ba96bcd9434046fd22891483a6d",
-    strip_prefix = "grpc-java-1.18.0",
-    urls = ["https://github.com/grpc/grpc-java/archive/v1.18.0.tar.gz"],
-)
-
-load("@io_grpc_grpc_java//:repositories.bzl", "grpc_java_repositories")
-
-grpc_java_repositories(
-    omit_com_google_protobuf = True,
 )
 
 maven_install(


### PR DESCRIPTION
- Add flags in .bazelrc so that broken changes introduced in recent
version of bazel don't break dependencies that still rely on old
behavior.

- Fetch io_grpc_grpc_java before everything else. Both go rules and
java_grpc depend on protobuf repo, however the go rules version depends
on a version which is broken for java
(https://github.com/bazelbuild/rules_go/pull/2105 addresses this).
Until that change is not submitted we need to force the java dep to be
downloaded first. Note that we cant revert to an older go rules version
since they are not compatible with newer bazel binaries (and no way to
work around via bazelrc).

Correct soulution is to have a repositories.bzl that loads common
dependencies up front in order to avoid this issues.