### PR TITLE
Multiplexing grpc service

### DIFF
--- a/waterfall/golang/mux/BUILD
+++ b/waterfall/golang/mux/BUILD
@@ -1,0 +1,40 @@
+licenses(["notice"])  # Apache 2.0
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+go_library(
+    name = "mux",
+    srcs = [
+        "addr.go",
+        "conn.go",
+        "mux.go",
+        "message.go",
+    ],
+    importpath = "github.com/google/waterfall/golang/mux",
+    deps = [
+        "//waterfall/proto:waterfall_go_grpc",
+        "//waterfall/golang/stream:stream",
+        "@org_golang_google_grpc//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "mux_test",
+    srcs = [
+        "mux_test.go",
+    ],
+    deps = [
+        "@org_golang_x_sync//errgroup:go_default_library",
+    ],
+    embed = [
+        ":mux",
+    ],
+    importpath = "github.com/google/waterfall/golang/mux",
+)
+

--- a/waterfall/golang/mux/addr.go
+++ b/waterfall/golang/mux/addr.go
@@ -1,0 +1,11 @@
+package mux
+
+type maddr string
+
+func (a maddr) Network() string {
+	return string(a)
+}
+
+func (a maddr) String() string {
+	return string(a)
+}

--- a/waterfall/golang/mux/conn.go
+++ b/waterfall/golang/mux/conn.go
@@ -30,19 +30,15 @@ func (mc *rwcConn) Close() error {
 
 func (mc *rwcConn) CloseRead() error {
 	if c, ok := mc.ReadWriteCloser.(halfCloser); ok {
-		fmt.Println("Half Closing: reads ...")
 		return c.CloseRead()
 	}
-	fmt.Println("Closing all ...")
 	return mc.ReadWriteCloser.Close()
 }
 
 func (mc *rwcConn) CloseWrite() error {
 	if c, ok := mc.ReadWriteCloser.(halfCloser); ok {
-		fmt.Println("Half Closing: writes ...")
 		return c.CloseWrite()
 	}
-	fmt.Println("Closing all ...")
 	return mc.ReadWriteCloser.Close()
 }
 

--- a/waterfall/golang/mux/conn.go
+++ b/waterfall/golang/mux/conn.go
@@ -1,0 +1,67 @@
+package mux
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"time"
+)
+
+type halfCloser interface {
+	CloseRead() error
+	CloseWrite() error
+}
+
+type rwcConn struct {
+	io.ReadWriteCloser
+}
+
+func (mc *rwcConn) Read(b []byte) (int, error) {
+	return mc.ReadWriteCloser.Read(b)
+}
+
+func (mc *rwcConn) Write(b []byte) (int, error) {
+	return mc.ReadWriteCloser.Write(b)
+}
+
+func (mc *rwcConn) Close() error {
+	return mc.ReadWriteCloser.Close()
+}
+
+func (mc *rwcConn) CloseRead() error {
+	if c, ok := mc.ReadWriteCloser.(halfCloser); ok {
+		fmt.Println("Half Closing: reads ...")
+		return c.CloseRead()
+	}
+	fmt.Println("Closing all ...")
+	return mc.ReadWriteCloser.Close()
+}
+
+func (mc *rwcConn) CloseWrite() error {
+	if c, ok := mc.ReadWriteCloser.(halfCloser); ok {
+		fmt.Println("Half Closing: writes ...")
+		return c.CloseWrite()
+	}
+	fmt.Println("Closing all ...")
+	return mc.ReadWriteCloser.Close()
+}
+
+func (mc *rwcConn) LocalAddr() net.Addr {
+	return maddr("muxconn")
+}
+
+func (mc *rwcConn) RemoteAddr() net.Addr {
+	return maddr("muxconn")
+}
+
+func (mc *rwcConn) SetDeadline(t time.Time) error {
+	return fmt.Errorf("unimplemented SetDeadline")
+}
+
+func (mc *rwcConn) SetReadDeadline(t time.Time) error {
+	return fmt.Errorf("unimplemented SetReadDeadline")
+}
+
+func (mc *rwcConn) SetWriteDeadline(t time.Time) error {
+	return fmt.Errorf("unimplemented SetWriteDeadline")
+}

--- a/waterfall/golang/mux/message.go
+++ b/waterfall/golang/mux/message.go
@@ -1,0 +1,45 @@
+package mux
+
+import (
+	"io"
+
+	waterfall_grpc "github.com/google/waterfall/proto/waterfall_go_grpc"
+)
+
+// Message implements stream.MessageReadWriteCloser interface
+type Message struct{}
+
+// BuildMsg returns a new message that can be sent through a forwarding stream.
+func (sm Message) BuildMsg() interface{} {
+	return new(waterfall_grpc.Message)
+}
+
+// GetBytes reads the bytes from the message.
+func (sm Message) GetBytes(m interface{}) ([]byte, error) {
+	msg, ok := m.(*waterfall_grpc.Message)
+	if !ok {
+		// this never happens
+		panic("incorrect type")
+	}
+
+	if len(msg.Payload) == 0 {
+		return nil, io.EOF
+	}
+	return msg.Payload, nil
+}
+
+// SetBytes sets the meessage bytes.
+func (sm Message) SetBytes(m interface{}, b []byte) {
+	msg, ok := m.(*waterfall_grpc.Message)
+	if !ok {
+		// this never happens
+		panic("incorrect type")
+	}
+
+	msg.Payload = b
+}
+
+// CloseMessage returns a new message to notify the other side that the stream is closed.
+func (sm Message) CloseMsg() interface{} {
+	return &waterfall_grpc.Message{}
+}

--- a/waterfall/golang/mux/mux.go
+++ b/waterfall/golang/mux/mux.go
@@ -1,0 +1,141 @@
+// Package mux multiplexes a connection using gRPC (http2) streams.
+// The gRPC server is started on a connection that can't be shared.
+// When the client connects to the server the connection is meant to be persistent.
+// Once the connection is establised the client can call NewStream and get multiple
+// streams on a single connection allowing to multiplex the base channel.
+package mux
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/waterfall/golang/stream"
+	waterfall_grpc "github.com/google/waterfall/proto/waterfall_go_grpc"
+	"google.golang.org/grpc"
+)
+
+// type server implements the waterfall grpc Multiplexer service.
+type server struct {
+	streamCh chan waterfall_grpc.Multiplexer_NewStreamServer
+}
+
+// singletonListener implements a net.Listener that guarantees Accept is only ever called once.
+type singletonListener struct {
+	net.Listener
+	used *int32
+}
+
+// Accept accepts a new connection if it has not accepted any connections yet.
+func (sl *singletonListener) Accept() (net.Conn, error) {
+	if !atomic.CompareAndSwapInt32(sl.used, 0, 1) {
+		return nil, fmt.Errorf("can't accept - channel in use")
+	}
+	return sl.Listener.Accept()
+}
+
+// NewStream sends the stream through the stream channel.
+func (svr *server) NewStream(s waterfall_grpc.Multiplexer_NewStreamServer) error {
+	svr.streamCh <- s
+
+	// Block until the connection is closed
+	<-s.Context().Done()
+
+	return s.Context().Err()
+}
+
+// Listener implements net.Listener multiplexed over a gRPC connection
+type Listener struct {
+	control *singletonListener
+	strms   chan waterfall_grpc.Multiplexer_NewStreamServer
+	svr     *grpc.Server
+}
+
+func (l *Listener) Close() error {
+	if err := l.control.Close(); err != nil {
+		return err
+	}
+	l.svr.Stop()
+	close(l.strms)
+	return nil
+}
+
+func (l *Listener) Addr() net.Addr {
+	return maddr("mux")
+}
+
+func (l *Listener) Accept() (net.Conn, error) {
+	strm, ok := <-l.strms
+	if !ok {
+		return nil, fmt.Errorf("error receiving next stream: grpc server stopped")
+	}
+	rw := stream.NewReadWriteCloser(strm, &Message{})
+	conn := &rwcConn{ReadWriteCloser: rw}
+	return conn, nil
+}
+
+// NewServer takes a base net.Listener that to start and create the multiplex server.
+func NewMultiplexedListener(base net.Listener) *Listener {
+	sl := &singletonListener{
+		Listener: base,
+		used:     new(int32),
+	}
+
+	ss := make(chan waterfall_grpc.Multiplexer_NewStreamServer)
+	gsvr := grpc.NewServer()
+	mux := &server{streamCh: ss}
+	waterfall_grpc.RegisterMultiplexerServer(gsvr, mux)
+
+	go func() {
+		gsvr.Serve(sl)
+	}()
+
+	return &Listener{
+		control: sl,
+		strms:   ss,
+		svr:     gsvr,
+	}
+}
+
+// ConBuilder create new connections multiplexed throug gRPC
+type ConnBuilder struct {
+	ctx    context.Context
+	client waterfall_grpc.MultiplexerClient
+	conn   *grpc.ClientConn
+}
+
+// NewConnBuilder creates a ConnBuilder using a base ReadWriteCloser
+func NewConnBuilder(ctx context.Context, rwc io.ReadWriteCloser) (*ConnBuilder, error) {
+	r := &rwcConn{
+		ReadWriteCloser: rwc,
+	}
+
+	d := func(string, time.Duration) (net.Conn, error) {
+		// TODO(mauriciogg): fail if a more than one dial happens.
+		return r, nil
+	}
+
+	cc, err := grpc.Dial("", grpc.WithDialer(d), grpc.WithInsecure())
+	return &ConnBuilder{
+		ctx:    ctx,
+		client: waterfall_grpc.NewMultiplexerClient(cc),
+		conn:   cc,
+	}, err
+}
+
+// MakeStream returns a ReadWriteCloser backed by a grpc stream.
+func (sb *ConnBuilder) Accept() (net.Conn, error) {
+	s, err := sb.client.NewStream(sb.ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &rwcConn{ReadWriteCloser: stream.NewReadWriteCloser(s, Message{})}, nil
+}
+
+func (sb *ConnBuilder) Close() error {
+	return sb.conn.Close()
+}

--- a/waterfall/golang/mux/mux_test.go
+++ b/waterfall/golang/mux/mux_test.go
@@ -1,0 +1,65 @@
+package mux
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"math/rand"
+	"net"
+	"testing"
+	"time"
+)
+
+func uniqueSocket() string {
+	return fmt.Sprintf("@muxtest_%05d", rand.Int31n(1<<16))
+}
+
+func TestConnect(t *testing.T) {
+	s := uniqueSocket()
+	l, err := net.Listen("unix", s)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ml := NewMultiplexedListener(l)
+
+	conn, err := net.Dial("unix", s)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cb, err := NewConnBuilder(context.Background(), conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		c, err := ml.Accept()
+		if err != nil {
+			panic(err)
+		}
+		log.Println("Accepted connection ...")
+		b := make([]byte, 5)
+		n, err := io.ReadFull(c, b)
+		if err != nil {
+			panic(err)
+		}
+		log.Printf("Read %d %s\n", n, string(b))
+	}()
+
+	go func() {
+		c, err := cb.Accept()
+		if err != nil {
+			panic(err)
+		}
+		log.Println("Created connection ...")
+		b := []byte("hello")
+		if _, err := c.Write(b); err != nil {
+			panic(err)
+		}
+		log.Printf("Wrote %s\n", string(b))
+	}()
+
+	time.Sleep(time.Second * 3)
+}

--- a/waterfall/proto/waterfall.proto
+++ b/waterfall/proto/waterfall.proto
@@ -152,3 +152,21 @@ service PortForwarder {
   rpc StopAll(google.protobuf.Empty) returns (google.protobuf.Empty);
   rpc List(google.protobuf.Empty) returns (ForwardedSessions);
 }
+
+// Multiplexer allows multiplexing multiple virtual connections through a single
+// connection. This allows us to multiplex over single stream channels (e.g USB connections)
+// without implementing most of the multiplexing logic.
+// This relies on gRPC over HTTP2 implementation, which maps a
+// method invocation to a HTTP2 stream. This is intended to be used by the
+// server and forwarder only (not actual clients).
+// Note that the gRPC lib migth decide to establish multiple HTTP2 connections, if for
+// example its reaching the current window limit in one of its HTTP2
+// connection. Given this, it is important that whatever Dialer/Listenr
+// implementation is provided to gRPC only creates a single connection.
+// See https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md.
+// The main idea is to call NewStream from the forwarder on each client
+// connection.
+service Multiplexer {
+  // NewStream returns a bidirectional byte stream.
+  rpc NewStream(stream Message) returns (stream Message);
+}

--- a/waterfall/proto/waterfall.proto
+++ b/waterfall/proto/waterfall.proto
@@ -159,13 +159,10 @@ service PortForwarder {
 // This relies on gRPC over HTTP2 implementation, which maps a
 // method invocation to a HTTP2 stream. This is intended to be used by the
 // server and forwarder only (not actual clients).
-// Note that the gRPC lib migth decide to establish multiple HTTP2 connections, if for
-// example its reaching the current window limit in one of its HTTP2
-// connection. Given this, it is important that whatever Dialer/Listenr
-// implementation is provided to gRPC only creates a single connection.
+// Note that the gRPC lib migth decide to establish multiple HTTP2 connections.
+// connection, but Dialers/Listeners instances provided to gRPC should only create
+// a single connection.
 // See https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md.
-// The main idea is to call NewStream from the forwarder on each client
-// connection.
 service Multiplexer {
   // NewStream returns a bidirectional byte stream.
   rpc NewStream(stream Message) returns (stream Message);


### PR DESCRIPTION
    gRPC multiplexing service
    
    Multiplexer allows multiplexing multiple virtual connections over a single connections.
    It has two main components
     - a net Listener that wraps a base Listener
       (Accept can only be called once on this listener) that is used to create
       a gRPC service that exposesa single method (NewStream) which simply
       returns a new bidirectional stream when its called.
     - a conncection builder that creates new net.Conn by calling NewStream
       on a gRPC cliet that dials the base listener of the service.