### PR TITLE
Allow running server forwarder over multiplex connections.

### DIFF
--- a/.continuous_integration/postsubmit.yml
+++ b/.continuous_integration/postsubmit.yml
@@ -2,13 +2,16 @@ platforms:
   ubuntu1804:
     build_targets:
     - "//waterfall/golang/bootstrap/..."
+    - "//waterfall/golang/forkfd/..."
     - "//waterfall/golang/forward/..."
+    - "//waterfall/golang/mux/..."
     - "//waterfall/golang/net/qemu/..."
     - "//waterfall/golang/stream/..."
     - "//waterfall/golang/server/..."
     test_targets:
     # - "//waterfall/golang/bootstrap/..."
     - "//waterfall/golang/forward/..."
+    - "//waterfall/golang/mux/..."
     - "//waterfall/golang/net/qemu/..."
     - "//waterfall/golang/stream/..."
     - "//waterfall/golang/server/..."

--- a/.continuous_integration/postsubmit.yml
+++ b/.continuous_integration/postsubmit.yml
@@ -6,7 +6,6 @@ platforms:
     - "//waterfall/golang/net/qemu/..."
     - "//waterfall/golang/stream/..."
     - "//waterfall/golang/server/..."
-    - "//waterfall/golang/aoa/..."
     test_targets:
     # - "//waterfall/golang/bootstrap/..."
     - "//waterfall/golang/forward/..."

--- a/waterfall/golang/forkfd/BUILD
+++ b/waterfall/golang/forkfd/BUILD
@@ -1,0 +1,18 @@
+licenses(["notice"])  # Apache 2.0
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_binary",
+    "go_test",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+go_binary(
+    name = "forkfd",
+    srcs = ["forkfd.go"],
+    goarch = "386",
+    goos = "linux",
+    pure = "on",
+    static = "on",
+)

--- a/waterfall/golang/forkfd/forkfd.go
+++ b/waterfall/golang/forkfd/forkfd.go
@@ -1,0 +1,76 @@
+// forkfd listens for tcp and spawns a waterfall server receiving on the opened connection.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+var (
+	addr      = flag.String("addr", "localhost:8080", "Address to listen on.")
+	waterfall = flag.String("waterfall", "/sbin/waterfall", "Path to the waterfall binary")
+)
+
+// launchWaterfallWithConn launches waterfall with a dupping the conn fd and making it accessible to the waterfall process
+func runWaterfall(waterfallPath string, rc syscall.RawConn) error {
+	var cmd *exec.Cmd
+	var cmdErr error
+	err := rc.Control(func(fd uintptr) {
+		log.Printf("Forking waterfall with fd: %d", fd)
+		f := os.NewFile(fd, "")
+		cmd = exec.Command(waterfallPath, "-addr", fmt.Sprintf("mux:%d", 3))
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		cmd.ExtraFiles = append(cmd.ExtraFiles, f)
+		cmdErr = cmd.Start()
+	})
+
+	if err != nil {
+		return err
+	}
+
+	if cmdErr != nil {
+		return err
+	}
+
+	return cmd.Wait()
+}
+
+func main() {
+	flag.Parse()
+
+	if *addr == "" {
+		log.Fatalf("Need to provide -addr.")
+	}
+
+	if *waterfall == "" {
+		log.Fatalf("Need to provide -waterfall.")
+	}
+
+	lis, err := net.Listen("tcp", *addr)
+	if err != nil {
+		log.Fatalf("Failed to listen: %v", err)
+	}
+
+	for {
+		conn, err := lis.Accept()
+		if err != nil {
+			log.Fatalf("Failed to accept: %v", err)
+		}
+
+		rawConn, err := conn.(*net.TCPConn).SyscallConn()
+		if err != nil {
+			log.Fatalf("Failed to get raw conn: %v", err)
+		}
+
+		if err := runWaterfall(*waterfall, rawConn); err != nil {
+			// just wait for the next connection on error
+			log.Printf("Error running waterfall: %v\n", err)
+		}
+	}
+}

--- a/waterfall/golang/forward/BUILD
+++ b/waterfall/golang/forward/BUILD
@@ -11,6 +11,7 @@ package(default_visibility = ["//visibility:public"])
 
 DEPS = [
         ":forward",
+        "//waterfall/golang/mux",
         "//waterfall/golang/net/qemu",
         "@org_golang_x_sync//errgroup:go_default_library",
 ]

--- a/waterfall/golang/mux/conn.go
+++ b/waterfall/golang/mux/conn.go
@@ -12,22 +12,28 @@ type halfCloser interface {
 	CloseWrite() error
 }
 
+// Conn implements net.Conn interface on a ReadWriteCloser.
 type Conn struct {
 	io.ReadWriteCloser
 }
 
+// Read reads from the underlying reader.
 func (mc *Conn) Read(b []byte) (int, error) {
 	return mc.ReadWriteCloser.Read(b)
 }
 
+// Write writes to the underlying writer.
 func (mc *Conn) Write(b []byte) (int, error) {
 	return mc.ReadWriteCloser.Write(b)
 }
 
+// Close closes the underlying closer.
 func (mc *Conn) Close() error {
 	return mc.ReadWriteCloser.Close()
 }
 
+// CloseRead closes the read side of the ReadWriteCloser if it implements CloseRead,
+// otherwise it closes the closer.
 func (mc *Conn) CloseRead() error {
 	if c, ok := mc.ReadWriteCloser.(halfCloser); ok {
 		return c.CloseRead()
@@ -35,6 +41,8 @@ func (mc *Conn) CloseRead() error {
 	return mc.ReadWriteCloser.Close()
 }
 
+// CloseRead closes the write side of the ReadWriteCloser if it implements CloseWrite,
+// otherwise it closes the closer.
 func (mc *Conn) CloseWrite() error {
 	if c, ok := mc.ReadWriteCloser.(halfCloser); ok {
 		return c.CloseWrite()
@@ -42,26 +50,32 @@ func (mc *Conn) CloseWrite() error {
 	return mc.ReadWriteCloser.Close()
 }
 
+// LocalAddr returns the conn addr.
 func (mc *Conn) LocalAddr() net.Addr {
 	return maddr("muxconn")
 }
 
+// RemoteAddr returns the conn add.
 func (mc *Conn) RemoteAddr() net.Addr {
 	return maddr("muxconn")
 }
 
+// SetDeadline -> unimplemented, calling it returns an error.
 func (mc *Conn) SetDeadline(t time.Time) error {
 	return fmt.Errorf("unimplemented SetDeadline")
 }
 
+// SetReadDeadline -> unimplemented, calling it returns an error.
 func (mc *Conn) SetReadDeadline(t time.Time) error {
 	return fmt.Errorf("unimplemented SetReadDeadline")
 }
 
+// SetWriteDeadline -> unimplemented, calling it returns an error.
 func (mc *Conn) SetWriteDeadline(t time.Time) error {
 	return fmt.Errorf("unimplemented SetWriteDeadline")
 }
 
+// NewConn returns a new Conn wrapping the ReadWriteCloser.
 func NewConn(rwc io.ReadWriteCloser) net.Conn {
 	return &Conn{rwc}
 }

--- a/waterfall/golang/mux/conn.go
+++ b/waterfall/golang/mux/conn.go
@@ -12,52 +12,56 @@ type halfCloser interface {
 	CloseWrite() error
 }
 
-type rwcConn struct {
+type Conn struct {
 	io.ReadWriteCloser
 }
 
-func (mc *rwcConn) Read(b []byte) (int, error) {
+func (mc *Conn) Read(b []byte) (int, error) {
 	return mc.ReadWriteCloser.Read(b)
 }
 
-func (mc *rwcConn) Write(b []byte) (int, error) {
+func (mc *Conn) Write(b []byte) (int, error) {
 	return mc.ReadWriteCloser.Write(b)
 }
 
-func (mc *rwcConn) Close() error {
+func (mc *Conn) Close() error {
 	return mc.ReadWriteCloser.Close()
 }
 
-func (mc *rwcConn) CloseRead() error {
+func (mc *Conn) CloseRead() error {
 	if c, ok := mc.ReadWriteCloser.(halfCloser); ok {
 		return c.CloseRead()
 	}
 	return mc.ReadWriteCloser.Close()
 }
 
-func (mc *rwcConn) CloseWrite() error {
+func (mc *Conn) CloseWrite() error {
 	if c, ok := mc.ReadWriteCloser.(halfCloser); ok {
 		return c.CloseWrite()
 	}
 	return mc.ReadWriteCloser.Close()
 }
 
-func (mc *rwcConn) LocalAddr() net.Addr {
+func (mc *Conn) LocalAddr() net.Addr {
 	return maddr("muxconn")
 }
 
-func (mc *rwcConn) RemoteAddr() net.Addr {
+func (mc *Conn) RemoteAddr() net.Addr {
 	return maddr("muxconn")
 }
 
-func (mc *rwcConn) SetDeadline(t time.Time) error {
+func (mc *Conn) SetDeadline(t time.Time) error {
 	return fmt.Errorf("unimplemented SetDeadline")
 }
 
-func (mc *rwcConn) SetReadDeadline(t time.Time) error {
+func (mc *Conn) SetReadDeadline(t time.Time) error {
 	return fmt.Errorf("unimplemented SetReadDeadline")
 }
 
-func (mc *rwcConn) SetWriteDeadline(t time.Time) error {
+func (mc *Conn) SetWriteDeadline(t time.Time) error {
 	return fmt.Errorf("unimplemented SetWriteDeadline")
+}
+
+func NewConn(rwc io.ReadWriteCloser) net.Conn {
+	return &Conn{rwc}
 }

--- a/waterfall/golang/server/BUILD
+++ b/waterfall/golang/server/BUILD
@@ -34,6 +34,7 @@ DEPS = [
     ":server",
     "//waterfall/golang/constants",
     "//waterfall/golang/stream",
+    "//waterfall/golang/mux",
     "//waterfall/golang/net/qemu",
     "//waterfall/proto:waterfall_go_grpc",
     "//waterfall/proto:waterfall_go_proto",


### PR DESCRIPTION
Introduced forkfd a new binary that listens for incoming connections to be
multiplexed and starts the server forking the process with a dup of the
connection fd. The forwarder can then connect to the server over
multiplexed streams on that endpoint.

forkfd opens a socket that can only handle a single stream at a time.
Once a connection is established the waterfall process is forked with
access to that fd. Waterall uses that connection to start a
Multiplexer service which is then used to start the waterfall server.
forfd blocks until the waterfall process is done since the communication
channel opened by forkfs is only suppose to ever have a single active
connection.

Also commit history includes merge and postsubmit file because git history got messed up and coulndt restore it.