### PR TITLE
Add option to propagate status code from shell commands

### DIFF
--- a/waterfall/golang/client/adb/adb.go
+++ b/waterfall/golang/client/adb/adb.go
@@ -38,7 +38,7 @@ import (
 const (
 	androidADBEnv          = "ANDROID_ADB"
 	androidSDKEnv          = "ANDROID_SDK_HOME"
-	propagateStatusCodeEnv = "PROPAGATE_STATUS_CODE"
+	propagateStatusCodeEnv = "WATERFALL_PROPAGATE_STATUS_CODE"
 )
 
 // ParseError represents an command line parsing error.


### PR DESCRIPTION
Originally ADB didnt report the exit status from commands
and on some later version started to report it.
Enable both modes via env variable PROPAGATE_STATUS_CODE.
Default mode does not propagate