### PR TITLE
Disable forward_usb_bin target in buildkyte

### DIFF
--- a/.continuous_integration/postsubmit.yml
+++ b/.continuous_integration/postsubmit.yml
@@ -5,7 +5,7 @@ platforms:
     - "//waterfall/golang/forkfd/..."
     - "//waterfall/golang/forward/..."
     # Disable usb target. Requires libusb to be present on host.
-    - "-//waterfall/golang/forward:forward_usb_bin",
+    - "-//waterfall/golang/forward:forward_usb_bin"
     - "//waterfall/golang/mux/..."
     - "//waterfall/golang/net/qemu/..."
     - "//waterfall/golang/stream/..."

--- a/.continuous_integration/postsubmit.yml
+++ b/.continuous_integration/postsubmit.yml
@@ -4,6 +4,8 @@ platforms:
     - "//waterfall/golang/bootstrap/..."
     - "//waterfall/golang/forkfd/..."
     - "//waterfall/golang/forward/..."
+    # Disable usb target. Requires libusb to be present on host.
+    - "-//waterfall/golang/forward:forward_usb_bin",
     - "//waterfall/golang/mux/..."
     - "//waterfall/golang/net/qemu/..."
     - "//waterfall/golang/stream/..."


### PR DESCRIPTION
requires libusb to be present on host.