### PR TITLE
Log line numbers in forward_bin

### DIFF
--- a/waterfall/golang/forward/forward_bin.go
+++ b/waterfall/golang/forward/forward_bin.go
@@ -89,6 +89,7 @@ func makeQemuBuilder(pa *utils.ParsedAddr) (connBuilder, error) {
 }
 
 func main() {
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
 	log.Println("Starting forwarding server ...")
 
 	if *listenAddr == "" || *connectAddr == "" {


### PR DESCRIPTION
Configure forward_bin's logger to print source file names and line numbers when logging.