### PR TITLE
Fix non-streamed installs

### DIFF
--- a/waterfall/golang/server/server.go
+++ b/waterfall/golang/server/server.go
@@ -45,6 +45,7 @@ const (
 	cmdCmd         = "cmd"
 	packageService = "package"
 
+	install        = "install"
 	installCreate  = "install-create"
 	installWrite   = "install-write"
 	installCommit  = "install-commit"
@@ -368,7 +369,7 @@ func (s *WaterfallServer) Install(rpc waterfall_grpc.Waterfall_InstallServer) er
 			return err
 		}
 
-		cmd := shell(ctx, append([]string{pmCmd}, append(ins.Args, f.Name())...))
+		cmd := shell(ctx, append([]string{pmCmd, install}, append(ins.Args, f.Name())...))
 		o, err := cmd.CombinedOutput()
 		s, err := exitCode(err)
 		if err != nil {


### PR DESCRIPTION
Non-streamed installs were missing the "install" command.

E.g.
pm /data/local/tmp/247277532.apk
now becomes
pm install /data/local/tmp/247277532.apk