### PR TITLE
Simplify build files

### DIFF
--- a/waterfall/golang/client/adb/BUILD.bazel
+++ b/waterfall/golang/client/adb/BUILD.bazel
@@ -3,46 +3,33 @@
 
 licenses(["notice"])  # Apache 2.0
 
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_binary")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 package(default_visibility = ["//visibility:public"])
-
-BINARY_DEPS = [
-        ":adb",
-        "@org_golang_google_grpc//:go_default_library",
-]
 
 go_binary(
     name = "adb_bin",
     srcs = [
         "adb_bin.go",
     ],
-    static = "on",
-    pure = "on",
-    deps = BINARY_DEPS,
-)
-
-go_binary(
-    name = "adb_bin_darwin",
-    srcs = [
-        "adb_bin.go",
+    deps = [
+        ":adb",
+        "@org_golang_google_grpc//:go_default_library",
     ],
-    goos = "darwin",
-    deps = BINARY_DEPS,
 )
 
 go_library(
     name = "adb",
     srcs = [
         "adb.go",
-        "adb_linux.go",
         "adb_darwin.go",
-    ],
-    deps = [
-        "@io_bazel_rules_go//proto/wkt:empty_go_proto",
-        "//waterfall/golang/client",
-        "//waterfall/proto:waterfall_go_grpc",
-        "@org_golang_google_grpc//:go_default_library",
+        "adb_linux.go",
     ],
     importpath = "github.com/google/waterfall/golang/client/adb",
+    deps = [
+        "//waterfall/golang/client",
+        "//waterfall/proto:waterfall_go_grpc",
+        "@io_bazel_rules_go//proto/wkt:empty_go_proto",
+        "@org_golang_google_grpc//:go_default_library",
+    ],
 )

--- a/waterfall/golang/forkfd/BUILD.bazel
+++ b/waterfall/golang/forkfd/BUILD.bazel
@@ -9,10 +9,6 @@ load(
 package(default_visibility = ["//visibility:public"])
 
 go_binary(
-    name = "forkfd_arm64",
+    name = "forkfd",
     srcs = ["forkfd.go"],
-    goarch = "arm64",
-    goos = "linux",
-    pure = "on",
-    static = "on",
 )

--- a/waterfall/golang/forward/BUILD.bazel
+++ b/waterfall/golang/forward/BUILD.bazel
@@ -9,50 +9,17 @@ load(
 
 package(default_visibility = ["//visibility:public"])
 
-DEPS = [
-    ":forward",
-    "//waterfall/golang/mux",
-    "//waterfall/golang/net/qemu",
-    "//waterfall/golang/utils",
-    "@org_golang_x_sync//errgroup:go_default_library",
-]
-
 # Host binary
 go_binary(
     name = "forward_bin",
     srcs = ["forward_bin.go"],
-    goos = "linux",
-    pure = "on",
-    static = "on",
-    deps = DEPS,
-)
-
-go_binary(
-    name = "forward_bin_darwin",
-    srcs = ["forward_bin.go"],
-    goos = "darwin",
-    deps = DEPS,
-)
-
-# Emulator binaries
-go_binary(
-    name = "forward_bin_386",
-    srcs = ["forward_bin.go"],
-    goarch = "386",
-    goos = "linux",
-    pure = "on",
-    static = "on",
-    deps = DEPS,
-)
-
-go_binary(
-    name = "forward_bin_arm",
-    srcs = ["forward_bin.go"],
-    goarch = "arm",
-    goos = "linux",
-    pure = "on",
-    static = "on",
-    deps = DEPS,
+    deps = [
+        ":forward",
+        "//waterfall/golang/mux",
+        "//waterfall/golang/net/qemu",
+        "//waterfall/golang/utils",
+        "@org_golang_x_sync//errgroup:go_default_library",
+    ],
 )
 
 # USB host binary
@@ -61,8 +28,14 @@ go_binary(
     name = "forward_usb_bin",
     srcs = ["forward_usb_bin.go"],
     cgo = True,
-    goos = "linux",
-    deps = DEPS + ["//waterfall/golang/aoa"],
+    deps = [
+        ":forward",
+        "//waterfall/golang/aoa",
+        "//waterfall/golang/mux",
+        "//waterfall/golang/net/qemu",
+        "//waterfall/golang/utils",
+        "@org_golang_x_sync//errgroup:go_default_library",
+    ],
 )
 
 go_library(

--- a/waterfall/golang/net/qemu/BUILD.bazel
+++ b/waterfall/golang/net/qemu/BUILD.bazel
@@ -51,7 +51,7 @@ go_test(
     ],
     importpath = "github.com/google/waterfall/golang/net/qemu",
     deps = [
-        "//waterfall/golang/testutils:testutils",
+        "//waterfall/golang/testutils",
         "@org_golang_x_net//context:go_default_library",
         "@org_golang_x_sync//errgroup:go_default_library",
     ],

--- a/waterfall/golang/server/BUILD.bazel
+++ b/waterfall/golang/server/BUILD.bazel
@@ -30,7 +30,7 @@ go_library(
     ],
 )
 
-DEPS = [
+BINARY_DEPS = [
     ":server",
     "//waterfall/golang/constants",
     "//waterfall/golang/stream",
@@ -45,6 +45,13 @@ DEPS = [
 ]
 
 go_binary(
+    name = "server_bin",
+    srcs = ["server_bin.go"],
+    deps = BINARY_DEPS,
+)
+
+# Build for emulator tests
+go_binary(
     name = "server_bin_386",
     srcs = ["server_bin.go"],
     # Attributes for an emulator binary
@@ -52,38 +59,5 @@ go_binary(
     goos = "linux",
     pure = "on",
     static = "on",
-    deps = DEPS,
-)
-
-go_binary(
-    name = "server_bin_amd64",
-    srcs = ["server_bin.go"],
-    # Attributes for an emulator binary
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
-    static = "on",
-    deps = DEPS,
-)
-
-go_binary(
-    name = "server_bin_arm",
-    srcs = ["server_bin.go"],
-    # Attributes for a physical device
-    goarch = "arm",
-    goos = "linux",
-    pure = "on",
-    static = "on",
-    deps = DEPS,
-)
-
-go_binary(
-    name = "server_bin_arm64",
-    srcs = ["server_bin.go"],
-    # Attributes for a physical device
-    goarch = "arm64",
-    goos = "linux",
-    pure = "on",
-    static = "on",
-    deps = DEPS,
+    deps = BINARY_DEPS,
 )


### PR DESCRIPTION
- remove most architecture/os specific go builds and prefer use of
  --platforms blaze flag