### PR TITLE
Add reverse forwarding support to waterfall

### DIFF
--- a/waterfall/golang/client/adb/adb_bin.go
+++ b/waterfall/golang/client/adb/adb_bin.go
@@ -69,7 +69,7 @@ func runCommand(ctx context.Context, args []string) error {
 			}
 
 			// Forward request uses a different service, so we need to dial accordingly.
-			if parsedArgs.Command == "forward" {
+			if parsedArgs.Command == "forward" || parsedArgs.Command == "reverse" {
 				cfn = func() (*grpc.ClientConn, error) {
 					return grpc.Dial(fmt.Sprintf("unix:@h2o_%s_xforward", parsedArgs.Device), grpc.WithInsecure())
 				}

--- a/waterfall/golang/forward/ports/ports_test.go
+++ b/waterfall/golang/forward/ports/ports_test.go
@@ -56,7 +56,7 @@ func runWaterfallServer(t *testing.T, addr string) {
 	defer lis.Close()
 
 	grpcServer := grpc.NewServer()
-	waterfall_grpc_pb.RegisterWaterfallServer(grpcServer, new(server.WaterfallServer))
+	waterfall_grpc_pb.RegisterWaterfallServer(grpcServer, server.New())
 	grpcServer.Serve(lis)
 }
 

--- a/waterfall/golang/server/server_bin.go
+++ b/waterfall/golang/server/server_bin.go
@@ -131,7 +131,7 @@ func main() {
 	}
 
 	grpcServer := grpc.NewServer(options...)
-	waterfall_grpc_pb.RegisterWaterfallServer(grpcServer, new(server.WaterfallServer))
+	waterfall_grpc_pb.RegisterWaterfallServer(grpcServer, server.New())
 
 	log.Println("Serving ...")
 	grpcServer.Serve(lis)

--- a/waterfall/proto/waterfall.proto
+++ b/waterfall/proto/waterfall.proto
@@ -144,6 +144,19 @@ service Waterfall {
   // Forward forwards the stream payload to the requested socket
   rpc Forward(stream ForwardMessage) returns (stream ForwardMessage);
 
+   // StartReverseForward starts a reverse forward session in the server.
+  // This call starts listening for connections on the requested address
+  // and expects to receive streams to pipe this connections through
+  // ReverseForward.
+  rpc StartReverseForward(ForwardMessage) returns (stream ForwardMessage);
+
+  // ReverseForward establish a stream that can be used to pipe data.
+  rpc ReverseForward(stream ForwardMessage) returns (stream ForwardMessage);
+
+  // StopReverseForward stops the forwarding session identified by
+  // ForwardMessage.
+  rpc StopReverseForward(ForwardMessage) returns (google.protobuf.Empty);
+
   // Version gets the version of the server.
   rpc Version(google.protobuf.Empty) returns (VersionMessage);
 }
@@ -166,22 +179,36 @@ message ForwardedSessions {
 // It allows start and stop forwarding connections when the waterfall client
 // is unable to mantains any state (e.g. the waterfall adb binary).
 service PortForwarder {
+  // ForwardPort starts a forwarding session from host to target.
   rpc ForwardPort(PortForwardRequest) returns (google.protobuf.Empty);
+
+  // ReverseForwardPort starts a forwarding session from target to host.
+  rpc ReverseForwardPort(PortForwardRequest) returns (google.protobuf.Empty);
+
+  // StopReverse stops the reverse forwarding session specified by
+  // PortForwardRequest.
+  rpc StopReverse(PortForwardRequest) returns (google.protobuf.Empty);
+
+  // Stop stops the port forwarding session specified by PortForwardRequest.
   rpc Stop(PortForwardRequest) returns (google.protobuf.Empty);
+
+  // StopAll stops all (host to target) forwarding sessions.
   rpc StopAll(google.protobuf.Empty) returns (google.protobuf.Empty);
+
+  // List lists the current forwarding sessions.
   rpc List(google.protobuf.Empty) returns (ForwardedSessions);
+
 }
 
 // Multiplexer allows multiplexing multiple virtual connections through a single
-// connection. This allows us to multiplex over single stream channels (e.g USB connections)
-// without implementing most of the multiplexing logic.
-// This relies on gRPC over HTTP2 implementation, which maps a
-// method invocation to a HTTP2 stream. This is intended to be used by the
-// server and forwarder only (not actual clients).
-// Note that the gRPC lib migth decide to establish multiple HTTP2 connections.
-// connection, but Dialers/Listeners instances provided to gRPC should only create
-// a single connection.
-// See https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md.
+// connection. This allows us to multiplex over single stream channels (e.g USB
+// connections) without implementing most of the multiplexing logic. This relies
+// on gRPC over HTTP2 implementation, which maps a method invocation to a HTTP2
+// stream. This is intended to be used by the server and forwarder only (not
+// actual clients). Note that the gRPC lib migth decide to establish multiple
+// HTTP2 connections. connection, but Dialers/Listeners instances provided to
+// gRPC should only create a single connection. See
+// https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md.
 service Multiplexer {
   // NewStream returns a bidirectional byte stream.
   rpc NewStream(stream Message) returns (stream Message);


### PR DESCRIPTION
For regular forwarding (i.e. from host to device) for each new connection
the client (here ports_bin) can simply make an RPC Forward call to create a
forwarding stream. The converse is not true (the server can't make calls
outside the device). To get around this we do the following:

1) initially the client sends an StartForward request to the server.
   This rpc call needs to be alive for the duration of the forwarding session.
2) Upon receiving such request, the server listens for connections on the
   desired socket. Each time it establish a new connection, it notifies the
   client sending a new Forward message of type OPEN via the StartForward rpc stream.
3) When the client gets this message, it makes a ReverseForward rpc call to the
   server.
4) The server then pipes the connection to the ReverseForward stream and the
   client pipes the ReverseForward stream to the connection on the host
   realizing the link.

That is, for each (src, dst) forwarding session there is one active StartForward request
at any given time and possibly multiple ReverseForward calls.

(src1, dst1), (src1, dst2) CAN'T be active at the same time.
(src1, dst1), (src2, dst1) CAN be active at the same time.