### PR TITLE
Fix concurrency bug in waterfall reverse forwarding

### DIFF
--- a/waterfall/golang/server/BUILD.bazel
+++ b/waterfall/golang/server/BUILD.bazel
@@ -62,3 +62,33 @@ go_binary(
     static = "on",
     deps = BINARY_DEPS,
 )
+
+go_binary(
+    name = "server_bin_arm",
+    srcs = ["server_bin.go"],
+    goarch = "arm",
+    goos = "linux",
+    pure = "on",
+    static = "on",
+    deps = BINARY_DEPS,
+)
+
+go_binary(
+    name = "server_bin_arm64",
+    srcs = ["server_bin.go"],
+    goarch = "arm64",
+    goos = "linux",
+    pure = "on",
+    static = "on",
+    deps = BINARY_DEPS,
+)
+
+go_binary(
+    name = "server_bin_amd64",
+    srcs = ["server_bin.go"],
+    goarch = "amd64",
+    goos = "linux",
+    pure = "on",
+    static = "on",
+    deps = BINARY_DEPS,
+)


### PR DESCRIPTION
In ReverseFoward server implementation, the OPEN request from ports_bin may arrive out of order, causing it to be matched to the wrong connection opened in StartReverseForwarding. Instead, map each connection to a connection id, ports_bin will always refer to the id when sending an OPEN request to ReverseForward, thus matching up with the right connection