### PR TITLE
Send Waterfall server logs to the kernel log when possible.

### DIFF
--- a/waterfall/golang/server/server_bin.go
+++ b/waterfall/golang/server/server_bin.go
@@ -101,13 +101,13 @@ func main() {
 	// adb will always create files with 0644 permission
 	syscall.Umask(0)
 
-	log.SetPrefix("waterfall: ")
 	// Log to the Kernel logs if possible
 	// This requires "file /dev/kmsg w" to be in the Waterfall service definition
 	if kmsgFd := os.Getenv("ANDROID_FILE__dev_kmsg"); kmsgFd != "" {
 		fd, err := strconv.Atoi(kmsgFd)
 		if err == nil {
 			log.SetOutput(os.NewFile(uintptr(fd), "/dev/kmsg"))
+			log.SetPrefix("waterfall: ")
 		}
 	}
 	log.Println("Starting waterfall server ...")

--- a/waterfall/golang/server/server_bin.go
+++ b/waterfall/golang/server/server_bin.go
@@ -63,6 +63,18 @@ func makeCredentials(cert, privateKey string) (credentials.TransportCredentials,
 	return credentials.NewTLS(&tls.Config{Certificates: []tls.Certificate{crt}}), nil
 }
 
+func configureLogging() {
+	// Log to the Kernel logs if possible
+	// This requires "file /dev/kmsg w" to be in the Waterfall service definition
+	if kmsgFd := os.Getenv("ANDROID_FILE__dev_kmsg"); kmsgFd != "" {
+		fd, err := strconv.Atoi(kmsgFd)
+		if err == nil {
+			log.SetOutput(os.NewFile(uintptr(fd), "/dev/kmsg"))
+			log.SetPrefix("waterfall: ")
+		}
+	}
+}
+
 func forkInDaemonMode(path string, paddr *utils.ParsedAddr, sessionID, cert, privateKey string) error {
 	a := fmt.Sprintf("%s:%s", paddr.Kind, paddr.Addr)
 	ef := []*os.File{}
@@ -101,15 +113,7 @@ func main() {
 	// adb will always create files with 0644 permission
 	syscall.Umask(0)
 
-	// Log to the Kernel logs if possible
-	// This requires "file /dev/kmsg w" to be in the Waterfall service definition
-	if kmsgFd := os.Getenv("ANDROID_FILE__dev_kmsg"); kmsgFd != "" {
-		fd, err := strconv.Atoi(kmsgFd)
-		if err == nil {
-			log.SetOutput(os.NewFile(uintptr(fd), "/dev/kmsg"))
-			log.SetPrefix("waterfall: ")
-		}
-	}
+	configureLogging()
 	log.Println("Starting waterfall server ...")
 
 	if *addr == "" {

--- a/waterfall/golang/server/server_bin.go
+++ b/waterfall/golang/server/server_bin.go
@@ -102,6 +102,14 @@ func main() {
 	syscall.Umask(0)
 
 	log.SetPrefix("waterfall: ")
+	// Log to the Kernel logs if possible
+	// This requires "file /dev/kmsg w" to be in the Waterfall service definition
+	if kmsgFd := os.Getenv("ANDROID_FILE__dev_kmsg"); kmsgFd != "" {
+		fd, err := strconv.Atoi(kmsgFd)
+		if err == nil {
+			log.SetOutput(os.NewFile(uintptr(fd), "/dev/kmsg"))
+		}
+	}
 	log.Println("Starting waterfall server ...")
 
 	if *addr == "" {


### PR DESCRIPTION
Write logs to /dev/kmsg if the file descriptor is passed to the Waterfall server by init.