### PR TITLE
Revert "Revert "Revert "Update several dependencies: Go Starlark rules, gRPC, Protobuf, etc. …"""

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,1 @@
 licenses(["notice"])  # Apache 2.0
-
-load("@bazel_gazelle//:def.bzl", "gazelle")
-
-# gazelle:prefix github.com/google
-gazelle(name = "gazelle")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,9 +19,9 @@ load("@rules_jvm_external//:defs.bzl", "maven_install")
 
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "c6003e1d2e7fefa78a3039f19f383b4f3a61e81be8c19356f85b6461998ad3db",
-    strip_prefix = "protobuf-3.17.3",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.17.3.tar.gz"],
+    sha256 = "e8c7601439dbd4489fe5069c33d374804990a56c2f710e00227ee5d8fd650e67",
+    strip_prefix = "protobuf-3.11.2",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.11.2.tar.gz"],
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
@@ -34,9 +34,9 @@ protobuf_deps()
 # java, so io_grpc_grpc_java needs to get the dep first.
 http_archive(
     name = "io_grpc_grpc_java",
-    sha256 = "340091bf58b05c1a7d4cae5c60d6acde7e82ce24f67d09a16638fe894c0e233f",
-    strip_prefix = "grpc-java-1.40.1",
-    urls = ["https://github.com/grpc/grpc-java/archive/v1.40.1.tar.gz"],
+    sha256 = "0378bf29029c48ed55f0d2ec210fb539cf1fc76a54da3ce9ecfc458d1ad5cb2b",
+    strip_prefix = "grpc-java-1.26.0",
+    urls = ["https://github.com/grpc/grpc-java/archive/v1.26.0.tar.gz"],
 )
 
 load("@io_grpc_grpc_java//:repositories.bzl", "grpc_java_repositories")
@@ -62,10 +62,10 @@ rules_proto_toolchains()
 # Go toolchains
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "8e968b5fcea1d2d64071872b12737bbb5514524ee5f0a4f54f5920266c261acb",
+    sha256 = "e88471aea3a3a4f19ec1310a55ba94772d087e9ce46e41ae38ecebe17935de7b",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.28.0/rules_go-v0.28.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.28.0/rules_go-v0.28.0.zip",
+        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/v0.20.3/rules_go-v0.20.3.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.20.3/rules_go-v0.20.3.tar.gz",
     ],
 )
 
@@ -77,14 +77,14 @@ load(
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.17")
+go_register_toolchains()
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "62ca106be173579c0a167deb23358fdfe71ffa1e4cfdddf5582af26520f1c66f",
+    sha256 = "86c6d481b3f7aedc1d60c1c211c6f76da282ae197c3b3160f54bd3a8f847896f",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/bazel-gazelle/releases/download/v0.19.1/bazel-gazelle-v0.19.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.19.1/bazel-gazelle-v0.19.1.tar.gz",
     ],
 )
 
@@ -96,36 +96,35 @@ go_repository(
     name = "org_golang_google_grpc",
     build_file_proto_mode = "disable",
     importpath = "google.golang.org/grpc",
-    sum = "h1:AGJ0Ih4mHjSeibYkFGh1dD9KJ/eOtZ93I6hoHhukQ5Q=",
-    version = "v1.40.0",
+    sum = "h1:zWTV+LMdc3kaiJMSTOFz2UgSBgx8RNQoTGiZu3fR9S0=",
+    version = "v1.32.0",
+
 )
 
 go_repository(
     name = "org_golang_x_net",
     importpath = "golang.org/x/net",
-    sum = "h1:E8wdt+zBjoxD3MA65wEc3pl25BsTi7tbkpwc4ANThjc=",
-    version = "v0.0.0-20210908191846-a5e095526f91",
+    sum = "h1:oWX7TPOiFAMXLq8o0ikBYfCJVlRHBcsciT5bXOrH628=",
+    version = "v0.0.0-20190311183353-d8887717615a",
 )
 
 go_repository(
     name = "org_golang_x_text",
     importpath = "golang.org/x/text",
-    sum = "h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=",
-    version = "v0.3.7",
+    sum = "h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=",
+    version = "v0.3.0",
 )
 
 go_repository(
     name = "org_golang_x_sys",
+    commit = "af09f7315aff1cbc48fb21d21aa55d67b4f914c5",
     importpath = "golang.org/x/sys",
-    sum = "h1:xrCZDmdtoloIiooiA9q0OQb9r8HejIHYoHGhGCe1pGg=",
-    version = "v0.0.0-20210910150752-751e447fb3d0",
 )
 
 go_repository(
     name = "org_golang_x_sync",
+    commit = "1d60e4601c6fd243af51cc01ddf169918a5407ca",
     importpath = "golang.org/x/sync",
-    sum = "h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=",
-    version = "v0.0.0-20210220032951-036812b2e83c",
 )
 
 go_repository(

--- a/waterfall/golang/adb/BUILD.bazel
+++ b/waterfall/golang/adb/BUILD.bazel
@@ -9,6 +9,8 @@ package(default_visibility = ["//visibility:public"])
 
 go_library(
     name = "adb",
-    srcs = ["adb.go"],
+    srcs = [
+        "adb.go",
+    ],
     importpath = "github.com/google/waterfall/golang/adb",
 )

--- a/waterfall/golang/aoa/BUILD.bazel
+++ b/waterfall/golang/aoa/BUILD.bazel
@@ -3,6 +3,7 @@ licenses(["notice"])  # Apache 2.0
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_binary",
     "go_test",
 )
 
@@ -12,13 +13,16 @@ package(default_visibility = ["//visibility:public"])
 go_library(
     name = "aoa",
     srcs = ["aoa.go"],
+    cgo = True,
     importpath = "github.com/google/waterfall/golang/aoa",
-    deps = ["@com_github_google_gousb//:go_default_library"],
+    deps = ["@com_github_google_gousb//:gousb"],
 )
 
 go_test(
     name = "aoa_test",
-    srcs = ["aoa_test.go"],
+    srcs = [
+        "aoa_test.go",
+    ],
     data = [
         "//waterfall/java/com/google/waterfall/usb:usb_service",
     ],
@@ -27,6 +31,6 @@ go_test(
     ],
     importpath = "github.com/google/waterfall/golang/aoa",
     deps = [
-        "@org_golang_x_sync//errgroup",
+        "@org_golang_x_sync//errgroup:go_default_library",
     ],
 )

--- a/waterfall/golang/bootstrap/BUILD.bazel
+++ b/waterfall/golang/bootstrap/BUILD.bazel
@@ -11,7 +11,9 @@ package(default_visibility = ["//visibility:public"])
 
 go_binary(
     name = "bootstrap_bin",
-    srcs = ["bootstrap_bin.go"],
+    srcs = [
+        "bootstrap_bin.go",
+    ],
     deps = [
         ":bootstrap",
         "//waterfall/golang/adb",
@@ -21,7 +23,9 @@ go_binary(
 # Keep this binary isolated, since it has a dependency on libusb.
 go_binary(
     name = "bootstrap_usb_bin",
-    srcs = ["bootstrap_usb_bin.go"],
+    srcs = [
+        "bootstrap_usb_bin.go",
+    ],
     deps = [
         "//waterfall/golang/adb",
         "@org_golang_google_grpc//:go_default_library",
@@ -30,16 +34,19 @@ go_binary(
 
 go_library(
     name = "bootstrap",
-    srcs = ["bootstrap.go"],
-    importpath = "github.com/google/waterfall/golang/bootstrap",
+    srcs = [
+        "bootstrap.go",
+    ],
     deps = [
         "//waterfall/golang/adb",
         "//waterfall/golang/client",
         "//waterfall/golang/net/qemu",
         "//waterfall/proto:waterfall_go_grpc",
+        "//waterfall/proto:waterfall_go_proto",
         "@org_golang_google_grpc//:go_default_library",
-        "@org_golang_x_sync//errgroup",
+        "@org_golang_x_sync//errgroup:go_default_library",
     ],
+    importpath = "github.com/google/waterfall/golang/bootstrap",
 )
 
 # integration test for the bootsrap process.
@@ -47,7 +54,10 @@ go_library(
 # since the bootstrap process will use real adb features.
 go_test(
     name = "bootstrap_test",
-    srcs = ["bootstrap_test.go"],
+    srcs = [
+        "bootstrap.go",
+        "bootstrap_test.go",
+    ],
     args = [
         "--waterfall_bin=$(location //waterfall/golang/server:server_bin_386)",
         "--forwarder_bin=$(location //waterfall/golang/forward:forward_bin)",
@@ -55,18 +65,21 @@ go_test(
         "--launcher_bin=$(location @android_test_support//tools/android/emulated_devices/generic_phone:android_23_x86)",
     ],
     data = [
-        "//waterfall/golang/forward:forward_bin",
         "//waterfall/golang/server:server_bin_386",
-        "@android_test_support//tools/android/emulated_devices/generic_phone:android_23_x86",
+        "//waterfall/golang/forward:forward_bin",
         "@androidsdk//:adb",
+        "@android_test_support//tools/android/emulated_devices/generic_phone:android_23_x86",
     ],
-    embed = [":bootstrap"],
-    importpath = "github.com/google/waterfall/golang/bootstrap",
     deps = [
         "//waterfall/golang/adb",
         "//waterfall/golang/client",
-        "//waterfall/golang/testutils",
+        "//waterfall/golang/forward",
+        "//waterfall/golang/net/qemu",
+        "//waterfall/golang/testutils:testutils",
         "//waterfall/proto:waterfall_go_grpc",
+        "//waterfall/proto:waterfall_go_proto",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_x_sync//errgroup:go_default_library",
     ],
+    importpath = "github.com/google/waterfall/golang/bootstrap",
 )

--- a/waterfall/golang/client/BUILD.bazel
+++ b/waterfall/golang/client/BUILD.bazel
@@ -9,11 +9,16 @@ package(default_visibility = ["//visibility:public"])
 
 go_library(
     name = "client",
-    srcs = ["client.go"],
+    srcs = [
+        "client.go",
+    ],
     importpath = "github.com/google/waterfall/golang/client",
     deps = [
         "//waterfall/golang/stream",
+        "//waterfall/golang/net/qemu",
         "//waterfall/proto:waterfall_go_grpc",
-        "@org_golang_x_sync//errgroup",
+        "//waterfall/proto:waterfall_go_proto",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_x_sync//errgroup:go_default_library",
     ],
 )

--- a/waterfall/golang/client/adb/BUILD.bazel
+++ b/waterfall/golang/client/adb/BUILD.bazel
@@ -9,7 +9,9 @@ package(default_visibility = ["//visibility:public"])
 
 go_binary(
     name = "adb_bin",
-    srcs = ["adb_bin.go"],
+    srcs = [
+        "adb_bin.go",
+    ],
     deps = [
         ":adb",
         "@org_golang_google_grpc//:go_default_library",

--- a/waterfall/golang/constants/BUILD.bazel
+++ b/waterfall/golang/constants/BUILD.bazel
@@ -9,6 +9,8 @@ package(default_visibility = ["//visibility:public"])
 
 go_library(
     name = "constants",
-    srcs = ["constants.go"],
+    srcs = [
+        "constants.go",
+    ],
     importpath = "github.com/google/waterfall/golang/constants",
 )

--- a/waterfall/golang/forkfd/BUILD.bazel
+++ b/waterfall/golang/forkfd/BUILD.bazel
@@ -3,18 +3,12 @@ licenses(["notice"])  # Apache 2.0
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_binary",
-    "go_library",
+    "go_test",
 )
 
 package(default_visibility = ["//visibility:public"])
 
 go_binary(
     name = "forkfd",
-    embed = [":forkfd_lib"],
-)
-
-go_library(
-    name = "forkfd_lib",
     srcs = ["forkfd.go"],
-    importpath = "github.com/google/waterfall/golang/forkfd",
 )

--- a/waterfall/golang/forward/BUILD.bazel
+++ b/waterfall/golang/forward/BUILD.bazel
@@ -47,8 +47,13 @@ go_library(
     ],
     importpath = "github.com/google/waterfall/golang/forward",
     deps = [
+        "//waterfall/golang/adb",
+        "//waterfall/golang/client",
+        "//waterfall/golang/net/qemu",
         "//waterfall/golang/stream",
         "//waterfall/proto:waterfall_go_grpc",
+        "//waterfall/proto:waterfall_go_proto",
+        "@org_golang_google_grpc//:go_default_library",
     ],
 )
 
@@ -72,7 +77,6 @@ go_test(
     name = "forward_test",
     srcs = [
         "forward_test.go",
-        "stream_test.go",
     ],
     args = [
         "--fwdr_bin=$(location :forward_bin)",
@@ -80,10 +84,8 @@ go_test(
     data = [
         "//waterfall/golang/forward:forward_bin",
     ],
-    embed = [":forward"],
     importpath = "github.com/google/waterfall/golang/forward",
     deps = [
         "//waterfall/golang/testutils",
-        "//waterfall/proto:waterfall_go_grpc",
     ],
 )

--- a/waterfall/golang/forward/ports/BUILD.bazel
+++ b/waterfall/golang/forward/ports/BUILD.bazel
@@ -11,7 +11,9 @@ package(default_visibility = ["//visibility:public"])
 
 go_binary(
     name = "ports_bin",
-    srcs = ["ports_bin.go"],
+    srcs = [
+        "ports_bin.go",
+    ],
     pure = "on",
     static = "on",
     deps = [
@@ -23,27 +25,36 @@ go_binary(
 
 go_library(
     name = "ports",
-    srcs = ["ports.go"],
+    srcs = [
+        "ports.go",
+    ],
     importpath = "github.com/google/waterfall/golang/forward/ports",
     deps = [
+        "@io_bazel_rules_go//proto/wkt:empty_go_proto",
+        "@org_golang_google_grpc//codes:go_default_library",
+        "@org_golang_google_grpc//status:go_default_library",
         "//waterfall/golang/forward",
         "//waterfall/proto:waterfall_go_grpc",
-        "@io_bazel_rules_go//proto/wkt:empty_go_proto",
-        "@org_golang_google_grpc//codes",
-        "@org_golang_google_grpc//status",
+        "//waterfall/proto:waterfall_go_proto",
     ],
 )
 
 go_test(
     name = "ports_test",
-    srcs = ["ports_test.go"],
-    embed = [":ports"],
+    srcs = [
+        "ports.go",
+        "ports_test.go",
+    ],
     importpath = "github.com/google/waterfall/golang/forward/ports",
     deps = [
-        "//waterfall/golang/server",
-        "//waterfall/golang/testutils",
-        "//waterfall/proto:waterfall_go_grpc",
         "@io_bazel_rules_go//proto/wkt:empty_go_proto",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes:go_default_library",
+        "@org_golang_google_grpc//status:go_default_library",
+        "//waterfall/proto:waterfall_go_grpc",
+        "//waterfall/proto:waterfall_go_proto",
+        "//waterfall/golang/forward",
+        "//waterfall/golang/server",
+        "//waterfall/golang/testutils",
     ],
 )

--- a/waterfall/golang/mux/BUILD.bazel
+++ b/waterfall/golang/mux/BUILD.bazel
@@ -13,22 +13,28 @@ go_library(
     srcs = [
         "addr.go",
         "conn.go",
-        "message.go",
         "mux.go",
+        "message.go",
     ],
     importpath = "github.com/google/waterfall/golang/mux",
     deps = [
-        "//waterfall/golang/stream",
         "//waterfall/proto:waterfall_go_grpc",
+        "//waterfall/golang/stream:stream",
         "@org_golang_google_grpc//:go_default_library",
     ],
 )
 
 go_test(
     name = "mux_test",
-    srcs = ["mux_test.go"],
+    srcs = [
+        "mux_test.go",
+    ],
+    deps = [
+        "@org_golang_x_sync//errgroup:go_default_library",
+    ],
     embed = [
         ":mux",
     ],
     importpath = "github.com/google/waterfall/golang/mux",
 )
+

--- a/waterfall/golang/net/qemu/BUILD.bazel
+++ b/waterfall/golang/net/qemu/BUILD.bazel
@@ -35,7 +35,10 @@ go_binary(
 
 go_test(
     name = "qemu_test",
-    srcs = ["qemu_test.go"],
+    srcs = [
+        "qemu.go",
+        "qemu_test.go",
+    ],
     args = [
         "--server=$(location :test_server)",
         "--launcher=$(location @android_test_support//tools/android/emulated_devices/generic_phone:android_23_x86)",
@@ -46,11 +49,10 @@ go_test(
         "@android_test_support//tools/android/emulated_devices/generic_phone:android_23_x86",
         "@android_test_support//tools/android/emulator:support/adb.turbo",
     ],
-    embed = [":qemu"],
     importpath = "github.com/google/waterfall/golang/net/qemu",
     deps = [
         "//waterfall/golang/testutils",
-        "@org_golang_x_net//context",
-        "@org_golang_x_sync//errgroup",
+        "@org_golang_x_net//context:go_default_library",
+        "@org_golang_x_sync//errgroup:go_default_library",
     ],
 )

--- a/waterfall/golang/server/BUILD.bazel
+++ b/waterfall/golang/server/BUILD.bazel
@@ -20,12 +20,13 @@ go_library(
         "//waterfall/golang/forward",
         "//waterfall/golang/stream",
         "//waterfall/proto:waterfall_go_grpc",
+        "//waterfall/proto:waterfall_go_proto",
         "@io_bazel_rules_go//proto/wkt:empty_go_proto",
         "@org_golang_google_grpc//:go_default_library",
-        "@org_golang_google_grpc//codes",
-        "@org_golang_google_grpc//metadata",
-        "@org_golang_google_grpc//status",
-        "@org_golang_x_sync//errgroup",
+        "@org_golang_google_grpc//codes:go_default_library",
+        "@org_golang_google_grpc//metadata:go_default_library",
+        "@org_golang_google_grpc//status:go_default_library",
+        "@org_golang_x_sync//errgroup:go_default_library",
     ],
 )
 

--- a/waterfall/golang/server/testing/BUILD.bazel
+++ b/waterfall/golang/server/testing/BUILD.bazel
@@ -3,11 +3,13 @@
 
 licenses(["notice"])  # Apache 2.0
 
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_test(
     name = "qemu_server_test",
-    srcs = ["qemu_server_test.go"],
+    srcs = [
+        "qemu_server_test.go",
+    ],
     args = [
         "--server=$(location //waterfall/golang/server:server_bin_386)",
         "--launcher=$(location @android_test_support//tools/android/emulated_devices/generic_phone:android_23_x86)",
@@ -26,18 +28,5 @@ go_test(
         "//waterfall/proto:waterfall_go_grpc",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_x_sync//errgroup:go_default_library",
-    ],
-)
-
-go_test(
-    name = "testing_test",
-    srcs = ["qemu_server_test.go"],
-    deps = [
-        "//waterfall/golang/client",
-        "//waterfall/golang/net/qemu",
-        "//waterfall/golang/testutils",
-        "//waterfall/proto:waterfall_go_grpc",
-        "@org_golang_google_grpc//:go_default_library",
-        "@org_golang_x_sync//errgroup",
     ],
 )

--- a/waterfall/golang/stream/BUILD.bazel
+++ b/waterfall/golang/stream/BUILD.bazel
@@ -30,8 +30,7 @@ go_test(
     name = "stream_test",
     srcs = [
         "stream_test.go",
-        "tar_test.go",
+        "stream.go",
     ],
-    embed = [":stream"],
     importpath = "github.com/google/waterfall/golang/stream",
 )

--- a/waterfall/golang/testutils/BUILD.bazel
+++ b/waterfall/golang/testutils/BUILD.bazel
@@ -7,8 +7,8 @@ package(default_visibility = ["//visibility:public"])
 go_library(
     name = "testutils",
     srcs = [
-        "emu.go",
         "net.go",
+        "emu.go",
         "runfiles.go",
     ],
     importpath = "github.com/google/waterfall/golang/testutils",

--- a/waterfall/golang/utils/BUILD.bazel
+++ b/waterfall/golang/utils/BUILD.bazel
@@ -6,21 +6,20 @@ package(default_visibility = ["//visibility:public"])
 
 go_library(
     name = "utils",
-    srcs = ["addr.go"],
+    srcs = [
+        "addr.go",
+    ],
     importpath = "github.com/google/waterfall/golang/utils",
 )
 
 go_test(
     name = "addr_test",
-    srcs = ["addr_test.go"],
+    srcs = [
+        "addr_test.go",
+    ],
     embed = [
         ":utils",
     ],
     importpath = "github.com/google/waterfall/golang/utils",
 )
 
-go_test(
-    name = "utils_test",
-    srcs = ["addr_test.go"],
-    embed = [":utils"],
-)

--- a/waterfall/java/com/google/waterfall/tar/BUILD.bazel
+++ b/waterfall/java/com/google/waterfall/tar/BUILD.bazel
@@ -11,7 +11,7 @@ java_library(
         "Tar.java",
     ],
     deps = [
-        "@com_google_guava_guava//jar",
         "@maven//:org_apache_commons_commons_compress",
+        "@com_google_guava_guava//jar",
     ],
 )

--- a/waterfall/javatests/com/google/waterfall/client/BUILD.bazel
+++ b/waterfall/javatests/com/google/waterfall/client/BUILD.bazel
@@ -17,7 +17,7 @@ java_test(
         "@com_google_guava_guava//jar",
         "@com_google_protobuf//:protobuf_java",
         "@com_google_protobuf//:protobuf_lite",
-        "@com_google_truth_truth",
+        "@com_google_truth_truth//:com_google_truth_truth",
         "@io_grpc_grpc_java//core",
         "@io_grpc_grpc_java//core:inprocess",
         "@io_grpc_grpc_java//core:util",

--- a/waterfall/javatests/com/google/waterfall/tar/BUILD.bazel
+++ b/waterfall/javatests/com/google/waterfall/tar/BUILD.bazel
@@ -10,7 +10,7 @@ java_test(
     deps = [
         "//waterfall/java/com/google/waterfall/tar",
         "//waterfall/javatests/com/google/waterfall/helpers",
-        "@com_google_truth_truth",
+        "@com_google_truth_truth//:com_google_truth_truth",
         "@maven//:org_junit_jupiter_junit_jupiter_api_5_3_2",
         "@maven//:org_junit_jupiter_junit_jupiter_engine",
     ],

--- a/waterfall/proto/BUILD.bazel
+++ b/waterfall/proto/BUILD.bazel
@@ -1,5 +1,3 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
-
 licenses(["notice"])  # Apache 2.0
 
 load(
@@ -9,6 +7,7 @@ load(
 load(
     "@io_bazel_rules_go//proto:def.bzl",
     "go_proto_library",
+    "go_grpc_library",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -36,9 +35,8 @@ go_proto_library(
     proto = ":control_socket_proto",
 )
 
-go_proto_library(
+go_grpc_library(
     name = "waterfall_go_grpc",
-    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
     importpath = "github.com/google/waterfall/proto/waterfall_go_grpc",
     proto = ":waterfall_proto",
     deps = [":waterfall_go_proto"],


### PR DESCRIPTION
Reverts google/devx-tools#92

Once again reverting. 32 bit ARM binaries built with this commit lead to crashes at runtime. Though the devices successfully build so it might be snapshot related.

BUG: Bad page map in process android.bg  pte:f42dbb79 pmd:48319831
addr:8a003000 vm_flags:00100073 anon_vma:c8306760 mapping:c826757c index:3c1
vma->vm_file->f_op->mmap: shmem_mmap+0x0/0x30
CPU: 0 PID: 1148 Comm: android.bg Not tainted 3.10.0+ #1
[<c0013744>] (unwind_backtrace+0x0/0xec) from [<c0011860>] (show_stack+0x10/0x14)
[<c0011860>] (show_stack+0x10/0x14) from [<c00bbbe4>] (print_bad_pte+0x118/0x1a8)
[<c00bbbe4>] (print_bad_pte+0x118/0x1a8) from [<c00bc8b4>] (vm_normal_page+0x6c/0xb8)
[<c00bc8b4>] (vm_normal_page+0x6c/0xb8) from [<c0126a04>] (smaps_pte_range+0xf0/0x274)
[<c0126a04>] (smaps_pte_range+0xf0/0x274) from [<c00cb4a0>] (walk_page_range+0x12c/0x244)
[<c00cb4a0>] (walk_page_range+0x12c/0x244) from [<c0126698>] (show_smap+0x7c/0x26c)
[<c0126698>] (show_smap+0x7c/0x26c) from [<c00fae90>] (seq_read+0x1ec/0x490)
[<c00fae90>] (seq_read+0x1ec/0x490) from [<c00db224>] (vfs_read+0x9c/0x174)
[<c00db224>] (vfs_read+0x9c/0x174) from [<c00db6d8>] (SyS_read+0x3c/0x78)
[<c00db6d8>] (SyS_read+0x3c/0x78) from [<c000e000>] (ret_fast_syscall+0x0/0x30)
Disabling lock debugging due to kernel taint