### PR TITLE
Store snapshot status in a persistent property instead of a file.

### DIFF
--- a/waterfall/golang/server/server.go
+++ b/waterfall/golang/server/server.go
@@ -710,9 +710,9 @@ func (s *WaterfallServer) Version(context.Context, *empty_pb.Empty) (*waterfall_
 	return &waterfall_grpc_pb.VersionMessage{Version: "0.0"}, nil
 }
 
-func (s *WaterfallServer) SnapshotShutdown(context.Context, *empty_pb.Empty) (*empty_pb.Empty, error) {
+func (s *WaterfallServer) SnapshotShutdown(ctx context.Context, _ *empty_pb.Empty) (*empty_pb.Empty, error) {
 	go s.server.GracefulStop()
-	return &empty_pb.Empty{}, snapshot.CreateSnapshotFile()
+	return &empty_pb.Empty{}, snapshot.CreateSnapshotProp(ctx)
 }
 
 // New initializes a new waterfall server

--- a/waterfall/golang/server/server.go
+++ b/waterfall/golang/server/server.go
@@ -712,7 +712,7 @@ func (s *WaterfallServer) Version(context.Context, *empty_pb.Empty) (*waterfall_
 
 func (s *WaterfallServer) SnapshotShutdown(ctx context.Context, _ *empty_pb.Empty) (*empty_pb.Empty, error) {
 	go s.server.GracefulStop()
-	return &empty_pb.Empty{}, snapshot.CreateSnapshotProp(ctx)
+	return &empty_pb.Empty{}, snapshot.SetSnapshotProp(ctx)
 }
 
 // New initializes a new waterfall server

--- a/waterfall/golang/server/server_bin.go
+++ b/waterfall/golang/server/server_bin.go
@@ -16,6 +16,7 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"flag"
 	"fmt"
@@ -133,8 +134,11 @@ func main() {
 	var lis net.Listener
 	var err error
 	address := *addr
-
-	if snapshot.IsSnapshot() {
+	isSnapshot, err := snapshot.IsSnapshot(context.Background())
+	if err != nil {
+		log.Fatalf("Could not determine snapshot status: %v", err)
+	}
+	if isSnapshot {
 		address = *snapshotAddr
 		log.Println("Snapshot run detected.")
 	}

--- a/waterfall/golang/server/snapshot.go
+++ b/waterfall/golang/server/snapshot.go
@@ -24,7 +24,7 @@ import (
 const snapshotProp = "persist.devx.snapshot"
 
 func CreateSnapshotProp(ctx context.Context) error {
-	cmd := exec.CommandContext(ctx, "setprop", snapshotProp)
+	cmd := exec.CommandContext(ctx, "setprop", snapshotProp, "1")
 	return cmd.Run()
 }
 

--- a/waterfall/golang/server/snapshot.go
+++ b/waterfall/golang/server/snapshot.go
@@ -23,7 +23,7 @@ import (
 
 const snapshotProp = "persist.devx.snapshot"
 
-func CreateSnapshotProp(ctx context.Context) error {
+func SetSnapshotProp(ctx context.Context) error {
 	cmd := exec.CommandContext(ctx, "setprop", snapshotProp, "1")
 	return cmd.Run()
 }

--- a/waterfall/golang/server/snapshot.go
+++ b/waterfall/golang/server/snapshot.go
@@ -16,18 +16,23 @@
 package snapshot
 
 import (
-	"errors"
-	"os"
+	"context"
+	"os/exec"
+	"strings"
 )
 
-const snapshotFile = "/data/snapshot"
+const snapshotProp = "persist.devx.snapshot"
 
-func CreateSnapshotFile() error {
-	_, err := os.Create(snapshotFile)
-	return err
+func CreateSnapshotProp(ctx context.Context) error {
+	cmd := exec.CommandContext(ctx, "setprop", snapshotProp)
+	return cmd.Run()
 }
 
-func IsSnapshot() bool {
-	_, err := os.Stat(snapshotFile)
-	return !errors.Is(err, os.ErrNotExist)
+func IsSnapshot(ctx context.Context) (bool, error) {
+	cmd := exec.CommandContext(ctx, "getprop", snapshotProp)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return false, err
+	}
+	return strings.HasPrefix(string(out), "1"), nil
 }


### PR DESCRIPTION
When rebooting in some circumstances, it is possible for this file to
disappear.