### PR TITLE
Enable vsock when driver is available

### DIFF
--- a/waterfall/golang/net/qemu/qemu.go
+++ b/waterfall/golang/net/qemu/qemu.go
@@ -559,10 +559,10 @@ func (q *Pipe) Addr() net.Addr {
 func MakePipe(socketName string) (*Pipe, error) {
 	// Prefer vsock if available. Vsock is only available in the >=S
 	// so we fall back to a legacy qemu device if driver not present.
-	// if _, err := os.Stat(vsockDriver); err == nil {
-	// 	log.Println("Using vsock driver")
-	// 	return &Pipe{socketName: socketName, useVsock: true}, nil
-	// }
+	if _, err := os.Stat(vsockDriver); err == nil {
+	 	log.Println("Using vsock driver")
+	 	return &Pipe{socketName: socketName, useVsock: true}, nil
+	}
 
 	log.Println("Using qemu driver")
 	if _, err := os.Stat(qemuDriver); err != nil {


### PR DESCRIPTION
This change must have gotten lost in my last commit after the large rebase from master.