### PR TITLE
Gate VSock connections behind a flag.

### DIFF
--- a/waterfall/golang/net/qemu/qemu.go
+++ b/waterfall/golang/net/qemu/qemu.go
@@ -553,10 +553,10 @@ func (q *Pipe) Addr() net.Addr {
 // MakePipe will return a new net.Listener
 // backed by a qemu either by a vsock virtio driver or
 // a qemu pipe device.
-func MakePipe(socketName string) (*Pipe, error) {
+func MakePipe(socketName string, allowVsock bool) (*Pipe, error) {
 	// Prefer vsock if available. Vsock is only available in the >=S
 	// so we fall back to a legacy qemu device if driver not present.
-	if _, err := os.Stat(vsockDriver); err == nil {
+	if _, err := os.Stat(vsockDriver); err == nil && allowVsock {
 	 	log.Println("Using vsock driver")
 	 	return &Pipe{socketName: socketName, useVsock: true}, nil
 	}
@@ -567,3 +567,4 @@ func MakePipe(socketName string) (*Pipe, error) {
 	}
 	return &Pipe{socketName: socketName, useVsock: false}, nil
 }
+

--- a/waterfall/golang/server/server_bin.go
+++ b/waterfall/golang/server/server_bin.go
@@ -61,6 +61,7 @@ var (
 	cert       = flag.String("cert", "", "The path to the server certificate")
 	privateKey = flag.String("private_key", "", "Path to the server private key")
 	daemon     = flag.Bool("daemon", false, "If true the server runs in daemon mode")
+	allowVsock = flag.Bool("allow_vsock", false, "If true, allow vsock guest connections")
 )
 
 func makeCredentials(cert, privateKey string) (credentials.TransportCredentials, error) {
@@ -159,13 +160,13 @@ func main() {
 
 	switch pa.Kind {
 	case utils.QemuGuest:
-		pip, err := qemu.MakePipe(pa.SocketName)
+		pip, err := qemu.MakePipe(pa.SocketName, *allowVsock)
 		if err != nil {
 			log.Fatalf("failed to open qemu_pipe %v", err)
 		}
 		lis = qemu.MakePipeConnBuilder(pip)
 	case utils.QemuCtrl:
-		pip, err := qemu.MakePipe(pa.SocketName)
+		pip, err := qemu.MakePipe(pa.SocketName, *allowVsock)
 		if err != nil {
 			log.Fatalf("failed to open qemu_pipe %v", err)
 		}


### PR DESCRIPTION
Some devices encounter issues when running waterfall over vsock, so we
need a way to conditionally disable it.