### PR TITLE
Increase wait time between retries to 500ms.

### DIFF
--- a/waterfall/golang/net/qemu/qemu.go
+++ b/waterfall/golang/net/qemu/qemu.go
@@ -495,7 +495,7 @@ func (q *Pipe) Accept() (net.Conn, error) {
 		if conn != nil {
 			// Got an error, close connection and try again
 			conn.Close()
-			time.Sleep(20 * time.Millisecond)
+			time.Sleep(500 * time.Millisecond)
 		}
 
 		conn, err = connFn()


### PR DESCRIPTION
In practice, this retry only happens before the waterfall forwarder
starts up - in which case, it doesn't make sense to spam the
emulator with connection retries.