### PR TITLE
Update waterfall to handle vsock connections more robustly.

### DIFF
--- a/waterfall/golang/net/qemu/qemu.go
+++ b/waterfall/golang/net/qemu/qemu.go
@@ -356,6 +356,7 @@ func (b *PipeConnBuilder) Accept() (net.Conn, error) {
 		rdy := []byte(rdyMsg)
 		if _, err := io.ReadFull(conn, rdy); err != nil {
 			conn.Close()
+			time.Sleep(500 * time.Millisecond)
 			continue
 		}
 		if !bytes.Equal([]byte(rdyMsg), rdy) {
@@ -369,7 +370,6 @@ func (b *PipeConnBuilder) Accept() (net.Conn, error) {
 		b.pendingConn = nil
 
 		q := makeConn(conn)
-
 		go q.closeConn()
 		return q, nil
 	}
@@ -515,7 +515,7 @@ func (q *Pipe) Accept() (net.Conn, error) {
 			if err != nil {
 				// The host has not opened the socket. Sleep and try again
 				conn.Close()
-				time.Sleep(100 * time.Millisecond)
+				time.Sleep(500 * time.Millisecond)
 				break
 			}
 			buff = buff[written:]

--- a/waterfall/golang/server/server.go
+++ b/waterfall/golang/server/server.go
@@ -224,7 +224,6 @@ func exitCode(err error) (int, error) {
 
 // Exec forks a new process with the desired command and pipes its output to the gRPC stream
 func (s *WaterfallServer) Exec(rpc waterfall_grpc_pb.Waterfall_ExecServer) error {
-
 	// The first message contains the actual command to execute.
 	// Implmented as a streaming method in order to support stdin redirection in the future.
 	cmdMsg, err := rpc.Recv()

--- a/waterfall/golang/server/server_bin.go
+++ b/waterfall/golang/server/server_bin.go
@@ -200,8 +200,8 @@ func main() {
 
 	options := []grpc.ServerOption{
 		grpc.WriteBufferSize(constants.WriteBufferSize),
-		// Timeout after 10s to terminate hanging VSock connections after booting from snapshot.
-		grpc.ConnectionTimeout(10 * time.Second),
+		// Don't timeout connections (1 year timeout)
+		grpc.ConnectionTimeout(8760 * time.Hour),
 	}
 	if *cert != "" || *privateKey != "" {
 		if *cert == "" || *privateKey == "" {


### PR DESCRIPTION
The gRPC timeout is switched back to 1year, since the 10s timeout causes
connections to occasionally disconnect. Updates will be made on the
forwarder side to close lingering connections instead.

Add 500ms delays at each point a connection retry is possible. This
should prevent waterfall from busy-looping on reads and using 100% CPU.