### PR TITLE
Swap the order in which connections are established from emulator->ho…

### DIFF
--- a/waterfall/golang/forward/BUILD.bazel
+++ b/waterfall/golang/forward/BUILD.bazel
@@ -20,6 +20,7 @@ go_binary(
         "//waterfall/golang/utils",
         "@com_github_mdlayher_vsock//:go_default_library",
         "@org_golang_x_sync//errgroup:go_default_library",
+        "@org_golang_x_sys//unix:go_default_library",
     ],
 )
 


### PR DESCRIPTION
Swap the order in which connections are established from emulator->host, to host->emulator. This means a guest connection will only be opened when a host connection is established, instead of always having a guest connection always open in a half-established state.

Additionally, have the forwarder intercept SIGTERM so it can close all open connections before exiting - this prevents connections on the waterfall from waiting on reads indefinitely, allowing for a graceful shutdown.
